### PR TITLE
fix: rework notify-send to not use systemd-run

### DIFF
--- a/system/usr/libexec/ublue-rebase
+++ b/system/usr/libexec/ublue-rebase
@@ -14,10 +14,10 @@ cancel-rebase() {
 trap cancel-rebase SIGTERM SIGINT
 
 function send-notification {
-    for user in $(w --no-header -u | awk '{print $1}' | grep -v root | sort | uniq); do
-        echo "Notifying $user: $1 $2"
-        systemd-run --machine="${user}"@.host --user notify-send "$1" "$2"
-    done
+    user_name=$(loginctl list-users -j | jq -r '.[] | select(.state == "active") | .user')
+    uid=$(loginctl list-users -j | jq -r '.[] | select(.state == "active") | .uid')
+         xdg_runtime_path="/run/user/$uid"
+    sudo -u "$user_name" DBUS_SESSION_BUS_ADDRESS=unix:path="$xdg_runtime_path"/bus notify-send "$1" "$2" --app-name="Aurora Preferences" -u NORMAL --icon distributor-logo
 }
 
 send-notification "System Rebase" "Starting rebase to $1"


### PR DESCRIPTION
Old version:
![Screenshot_20250323_182554](https://github.com/user-attachments/assets/e1aa49e7-a799-4511-8516-9fa2d042f18c)

New Version:
![Screenshot_20250323_182315](https://github.com/user-attachments/assets/aebde3c2-e4c9-44ff-9edf-23dedab4b4a9)

Closes #8.
